### PR TITLE
NAMB-368 apt-get git

### DIFF
--- a/python-3.5.3-slim-mjml/Dockerfile
+++ b/python-3.5.3-slim-mjml/Dockerfile
@@ -5,7 +5,7 @@ ENV MJML="mjml@3.2.2"
 RUN apt-get update && \
     apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
-    apt-get install -y nodejs gettext && \
+    apt-get install -y nodejs gettext git && \
     npm install -g $MJML && \
     apt-get purge -y --auto-remove curl && \
     apt-get autoremove --purge -y && \


### PR DESCRIPTION
Needed for pypi requirements available only via `git+git://` protocol