### PR TITLE
Change python-distutils -> libpython3.6-stdlib

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update &&  \
     apt-get update && apt-get install -y --no-install-recommends \
     libpython3.6-dev python2.7-minimal libxml2-dev libxslt1-dev gettext zlib1g-dev libjpeg-dev \
     libpng12-0 postgresql-client-9.6 git openssh-client heroku \
-    python3.6 python3.6-venv python3-distutils python3.6-dev make \
+    python3.6 python3.6-venv libpython3.6 libpython3.6-stdlib python3.6-dev make \
     gcc sudo && \
     apt-get remove -y --purge software-properties-common && \
     apt-get clean -y && \

--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -9,7 +9,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get remove -y --purge software-properties-common curl gnupg2 apt-transport-https && \
     apt-get clean -y && \
     apt-get autoremove --purge -y && \
-    rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
+    rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918881
+# debian unstable only ships distutils with python3.7
+# this is an ugly hack to get it working for 3.6
+    cp -arv /usr/lib/python3.7/distutils /usr/lib/python3.6
 
 # Ensure python3.6 is default
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 10 && \

--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl -L https://cli-assets.heroku.com/apt/release.key | apt-key add - && \
     add-apt-repository "deb https://cli-assets.heroku.com/branches/stable/apt ./" && \
     apt-get update && apt-get install -y --no-install-recommends git openssh-client heroku python3.6-minimal python3.6-venv python3-pip python3-setuptools python3-wheel sudo make && \
-    apt-get install -y python3.6-distutils && \
+    apt-get install -y libpython3.6 libpython3.6-stdlib && \
     apt-get remove -y --purge software-properties-common curl gnupg2 apt-transport-https && \
     apt-get clean -y && \
     apt-get autoremove --purge -y && \


### PR DESCRIPTION
The debs the python repo builds have changed, but you can still install
previous versions.

Hence installing python-disutils would install 3.6.5
Which would conflict with the other packages upgraded to 3.6.7

note the differing package numbers in the output below

```
```Step 8/23 : RUN apt-cache policy python3-lib2to3 python3-distutils python3.6 python3.6-venv python3.6-dev
 ---> Running in c9c396f45399
python3-lib2to3:
  Installed: (none)
  Candidate: 3.6.5-3~16.04.york0.2
  Version table:
     3.6.5-3~16.04.york0.2 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3-distutils:
  Installed: (none)
  Candidate: 3.6.5-3~16.04.york0.2
  Version table:
     3.6.5-3~16.04.york0.2 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3.6:
  Installed: (none)
  Candidate: 3.6.7-1~16.04.york3
  Version table:
     3.6.7-1~16.04.york3 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3.6-venv:
  Installed: (none)
  Candidate: 3.6.7-1~16.04.york3
  Version table:
     3.6.7-1~16.04.york3 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3.6-dev:
  Installed: (none)
  Candidate: 3.6.7-1~16.04.york3
  Version table:
     3.6.7-1~16.04.york3 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
Step 8/23 : RUN apt-cache policy python3-lib2to3 python3-distutils python3.6 python3.6-venv python3.6-dev
 ---> Running in c9c396f45399
python3-lib2to3:
  Installed: (none)
  Candidate: 3.6.5-3~16.04.york0.2
  Version table:
     3.6.5-3~16.04.york0.2 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3-distutils:
  Installed: (none)
  Candidate: 3.6.5-3~16.04.york0.2
  Version table:
     3.6.5-3~16.04.york0.2 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3.6:
  Installed: (none)
  Candidate: 3.6.7-1~16.04.york3
  Version table:
     3.6.7-1~16.04.york3 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3.6-venv:
  Installed: (none)
  Candidate: 3.6.7-1~16.04.york3
  Version table:
     3.6.7-1~16.04.york3 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages
python3.6-dev:
  Installed: (none)
  Candidate: 3.6.7-1~16.04.york3
  Version table:
     3.6.7-1~16.04.york3 500
        500 http://ppa.launchpad.net/jonathonf/python-3.6/ubuntu xenial/main amd64 Packages```
```