### PR TITLE
GK-46 Match the node version we preload w/ root

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -57,8 +57,8 @@ ENV LANGUAGE C.UTF-8
 USER ciuser
 WORKDIR /home/ciuser
 
-# Preload NodeJS 8.5.0
-RUN nave use 8.5.0 node --version
+# Preload NodeJS 12.6.0
+RUN nave use 12.6.0 node --version
 
 COPY bashrc .docker.bashrc
 RUN cat .docker.bashrc >> .bashrc && rm .docker.bashrc


### PR DESCRIPTION
**Why**
We're upgrading node in https://github.com/streetteam/root/pull/10701

**What**
- [x] Change the node version we preload, to match the version we use in monorepo root
