### PR TITLE
install unzip for tfenv

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:xenial
 # add all our standard system dependencies, and then clean up after ourselves
 RUN apt-get update &&  \
     apt-get install -y --no-install-recommends apt-utils software-properties-common curl apt-transport-https \
-    build-essential checkinstall make gcc sudo && \
+    build-essential checkinstall make gcc sudo unzip && \
     # python3.7 related dependencies
     apt-get install -y --no-install-recommends python2.7-minimal libreadline-gplv2-dev \
     libncursesw5-dev libssl-dev sqlite3 libsqlite3-dev tk-dev libgdbm-dev libc6-dev \


### PR DESCRIPTION
We need unzip for tfenv

to test:
- do `docker build circleci-base`
- run `docker run -it {NEW IMAGE ID}`
then when you are in the container,
- `git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
    sudo ln -s ~/.tfenv/bin/* /usr/local/bin`
- `sudo tfenv install 0.12.5`, then `terraform version` should show 0.12.5