### PR TITLE
remove apex and updated terraform install to use tfenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,6 @@ jobs:
           docker push "${DOCKER_ORG}/circleci-fullstack-chrome:${CIRCLE_BRANCH}"
           docker push "${DOCKER_ORG}/circleci-fullstack-cypress:${CIRCLE_BRANCH}"
           docker push "${DOCKER_ORG}/circleci-deploy:${CIRCLE_BRANCH}"
-          docker push "${APEX_ROUTER_ECR_REPO}:${CIRCLE_BRANCH}"
-
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ jobs:
           docker push "${DOCKER_ORG}/circleci-fullstack-cypress:${CIRCLE_BRANCH}"
           docker push "${DOCKER_ORG}/circleci-deploy:${CIRCLE_BRANCH}"
           docker push "${APEX_ROUTER_ECR_REPO}:${CIRCLE_BRANCH}"
-          aws ecs update-service --region us-east-1 --cluster verve-apex-lb --service verve-apex-lb --force-new-deployment
 
 workflows:
   version: 2

--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -17,9 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make altinstall && \
 
     # Install terraform
-    wget https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.5_linux_amd64.zip -P /usr/src && \
-        unzip /usr/src/terraform_0.12.5_linux_amd64.zip -d /usr/src && \
-    mv /usr/src/terraform /usr/local/bin && \
+    git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
+    mkdir -p ~/.local/bin && \
+    source ~/.profile && \
+    ln -s ~/.tfenv/bin/* ~/.local/bin && \
+    tfenv install 0.12.5
 
     # install pip
     # Removing lsb_release as it causes problem when installing pip

--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mkdir -p ~/.local/bin && \
     . ~/.profile && \
     ln -s ~/.tfenv/bin/* ~/.local/bin && \
-    tfenv install 0.12.5
+    tfenv install 0.12.5 && \
 
     # install pip
     # Removing lsb_release as it causes problem when installing pip

--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -17,10 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make altinstall && \
 
     # Install terraform
-    git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
-    mkdir -p ~/.local/bin && \
-    . ~/.profile && \
-    ln -s ~/.tfenv/bin/* ~/.local/bin && \
+    git clone https://github.com/tfutils/tfenv.git /usr/src/.tfenv && \
+    ln -s /usr/src/.tfenv/bin/* /usr/local/bin && \
     tfenv install 0.12.5 && \
 
     # install pip
@@ -50,6 +48,3 @@ ENV LANGUAGE C.UTF-8
 
 USER ciuser
 WORKDIR /home/ciuser
-
-COPY bashrc .docker.bashrc
-RUN cat .docker.bashrc >> .bashrc && rm .docker.bashrc

--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Install terraform
     git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
     mkdir -p ~/.local/bin && \
-    source ~/.profile && \
+    . ~/.profile && \
     ln -s ~/.tfenv/bin/* ~/.local/bin && \
     tfenv install 0.12.5
 

--- a/circleci-fullstack/Dockerfile
+++ b/circleci-fullstack/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Install terraform
     git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
     mkdir -p ~/.local/bin && \
-    source ~/.profile && \
+    . ~/.profile && \
     ln -s ~/.tfenv/bin/* ~/.local/bin && \
     tfenv install 0.12.5
 

--- a/circleci-fullstack/Dockerfile
+++ b/circleci-fullstack/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get autoremove --purge -y && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
     # Install terraform
-    wget https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.5_linux_amd64.zip -P /usr/src && \
-    unzip /usr/src/terraform_0.12.5_linux_amd64.zip -d /usr/src && \
-    mv /usr/src/terraform /usr/local/bin
+    git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
+    mkdir -p ~/.local/bin && \
+    source ~/.profile && \
+    ln -s ~/.tfenv/bin/* ~/.local/bin && \
+    tfenv install 0.12.5
 
 # Ensure python3.6 is default
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.7 10 && \

--- a/circleci-fullstack/Dockerfile
+++ b/circleci-fullstack/Dockerfile
@@ -12,10 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get autoremove --purge -y && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
     # Install terraform
-    git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
-    mkdir -p ~/.local/bin && \
-    . ~/.profile && \
-    ln -s ~/.tfenv/bin/* ~/.local/bin && \
+    git clone https://github.com/tfutils/tfenv.git /usr/src/.tfenv && \
+    ln -s /usr/src/.tfenv/bin/* /usr/local/bin && \
     tfenv install 0.12.5
 
 # Ensure python3.6 is default


### PR DESCRIPTION
- CI nightly job is failing after we removed ECS cluster: https://circleci.com/gh/streetteam/docker-images/689
- Using tfenv to install terraform 