### PR TITLE
install heroku plugins on docker image

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -57,6 +57,10 @@ ENV LANGUAGE C.UTF-8
 USER ciuser
 WORKDIR /home/ciuser
 
+# heroku plugins installation
+RUN heroku plugins:install heroku-repo && \
+    heroku plugins:install heroku-releases-retry
+
 # Preload NodeJS 12.6.0
 RUN nave use 12.6.0 node --version
 


### PR DESCRIPTION
to test:
- run `docker build circleci-base`
- run `docker run -it {IMAGENAME}`
- when you are in the container, run `heroku plugins`, you should see both `heroku-repo` and `heroku-releases-retry`