### PR TITLE
Add libgnutls28-dev apt dep

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update &&  \
     # python3.7 related dependencies
     apt-get install -y --no-install-recommends python2.7-minimal libreadline-gplv2-dev \
     libncursesw5-dev libssl-dev sqlite3 libsqlite3-dev tk-dev libgdbm-dev libc6-dev \
-    libbz2-dev libffi-dev zlib1g-dev gettext libgettextpo-dev && \
+    libbz2-dev libffi-dev zlib1g-dev gettext libgettextpo-dev libgnutls28-dev && \
     # airflow related deps
     apt-get install -y --no-install-recommends librabbitmq-dev libtool-bin pkg-config autoconf automake && \
     # download python3.7 and install


### PR DESCRIPTION
needed for pycurl
https://stackoverflow.com/questions/46290556/installing-pycurl-with-fatal-error-gnutls-gnutls-h-no-such-file-or-directory