### PR TITLE
upgrade pg_client version to 11

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update &&  \
     add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main"  && \
     curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && apt-get install -y --no-install-recommends \
-    postgresql-client-9.6 git openssh-client heroku && \
+    postgresql-client-11 git openssh-client heroku && \
     apt-get remove -y --purge software-properties-common && \
     apt-get clean -y && \
     apt-get autoremove --purge -y && \


### PR DESCRIPTION
To test:
- run `docker build circleci-base --tag circleci-base`
- run `docker run -it circleci-base:latest`

when you are in the container, run
`pg_dump --version`
`psql --version`
they should both output 11.5