### PR TITLE
do not remove build essentials

### DIFF
--- a/circleci-fullstack/Dockerfile
+++ b/circleci-fullstack/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential ruby ruby-dev unzip \
     redis-server rabbitmq-server ca-certificates && \
     gem install mailcatcher -v 0.6.5 --no-ri --no-rdoc &&  \
-    apt-get remove -y --purge build-essential ruby-dev && \
+    apt-get remove -y --purge ruby-dev && \
     apt-get clean -y && \
     apt-get autoremove --purge -y && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \


### PR DESCRIPTION
This seems to be causing problem with installing gdal, if we are going to use circle-fullstack