### PR TITLE
tfenv use command

### DIFF
--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git clone https://github.com/tfutils/tfenv.git /usr/src/.tfenv && \
     ln -s /usr/src/.tfenv/bin/* /usr/local/bin && \
     tfenv install 0.12.17 && \
+    tfenv use 0.12.17 && \
+
 
     # install pip
     # Removing lsb_release as it causes problem when installing pip

--- a/circleci-fullstack/Dockerfile
+++ b/circleci-fullstack/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Install terraform
     git clone https://github.com/tfutils/tfenv.git /usr/src/.tfenv && \
     ln -s /usr/src/.tfenv/bin/* /usr/local/bin && \
-    tfenv install 0.12.17
+    tfenv install 0.12.17 && \
+    tfenv use 0.12.17
 
 # Ensure python3.6 is default
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.7 10 && \


### PR DESCRIPTION
https://sentry.io/organizations/pollen/issues/1590766638/?referrer=slack
`Installation of terraform v0.12.17 successful. To make this your default version, run 'tfenv use 0.12.17'`
from https://circleci.com/gh/streetteam/docker-images/775 