### PR TITLE
install sentry-cli for circle-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker:18.01.0-ce-git
+      - image: docker:19.03.8
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
       - image: docker:18.01.0-ce-git
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
+#          docker_layer_caching: true
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run: |
           apk add --no-cache py-pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker:19.03.8
+      - image: docker:19.03.8-git
     steps:
       - checkout
-      - setup_remote_docker
-#          docker_layer_caching: true
+      - setup_remote_docker:
+          version: 19.03.8
+          docker_layer_caching: true
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run: |
           apk add --no-cache py-pip

--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -42,6 +42,9 @@ RUN pip install --upgrade pip requests setuptools
 # Install nave for NodeJS versions
 RUN curl -o /usr/bin/nave https://raw.githubusercontent.com/isaacs/nave/master/nave.sh && \
     chmod +x /usr/bin/nave
+
+# Install Sentry-cli, for FE sourcemap upload
+RUN curl -sL https://sentry.io/get-cli/ | bash
     
 # Restrict further actions to the non-root 'ciuser' user, but with access to sudo
 RUN useradd -ms /bin/bash ciuser && echo "ciuser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Since we are going to upload sourcemaps via terraform.
It's better to have sentry-cli available on the docker image, so we don't have to install it every time.

How to test:
- `docker build circleci-deploy`
- `docker run -it {image_id}`
- once in the container, do `sentry-cli`, the command should be available