### PR TITLE
[UNI-1622] Upgrade nodejs version to LTS

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -67,8 +67,8 @@ WORKDIR /home/ciuser
 RUN heroku plugins:install heroku-repo && \
     heroku plugins:install heroku-releases-retry
 
-# Preload NodeJS 12.6.0
-RUN nave use 12.6.0 node --version
+# Preload NodeJS 14.15.4 LTS
+RUN nave use 14.15.4 node --version
 
 COPY bashrc .docker.bashrc
 RUN cat .docker.bashrc >> .bashrc && rm .docker.bashrc


### PR DESCRIPTION
So projects can benefit from latest long term support version.