### PR TITLE
[UNI-1700] Install Node in /usr/local/bin

### DIFF
--- a/circleci-base/Dockerfile
+++ b/circleci-base/Dockerfile
@@ -74,6 +74,7 @@ RUN heroku plugins:install heroku-repo && \
 
 # Preload NodeJS 14.15.4 LTS
 RUN nave use 14.15.4 node --version
+RUN nave usemain 14.15.4
 
 COPY bashrc .docker.bashrc
 RUN cat .docker.bashrc >> .bashrc && rm .docker.bashrc


### PR DESCRIPTION
This allows Lerna to correctly build in these base images, allowing the same Dockerfiles to be used as part of a local development stack.