### PR TITLE
Added docker image for python-gdal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           docker build "${DOCKER_ARGS}" -t "${DOCKER_ORG}/circleci-deploy:${CIRCLE_BRANCH}" -t circleci-deploy circleci-deploy/
           docker build "${DOCKER_ARGS}" -t "${DOCKER_ORG}/circleci-postgres-ram:${CIRCLE_BRANCH}" -t circleci-postgres-ram circleci-postgres-ram/
           docker build "${DOCKER_ARGS}" -t "${DOCKER_ORG}/dev-stack:${CIRCLE_BRANCH}" -t dev-stack dev-stack/
+          docker build "${DOCKER_ARGS}" -t "${DOCKER_ORG}/python-gdal:${CIRCLE_BRANCH}" -t dev-stack dev-stack/
       - run: |
           docker push "${DOCKER_ORG}/circleci-base:${CIRCLE_BRANCH}"
           docker push "${DOCKER_ORG}/circleci-fullstack:${CIRCLE_BRANCH}"
@@ -32,6 +33,7 @@ jobs:
           docker push "${DOCKER_ORG}/circleci-deploy:${CIRCLE_BRANCH}"
           docker push "${DOCKER_ORG}/circleci-postgres-ram:${CIRCLE_BRANCH}"
           docker push "${DOCKER_ORG}/dev-stack:${CIRCLE_BRANCH}"
+          docker push "${DOCKER_ORG}/python-gdal:${CIRCLE_BRANCH}"
 workflows:
   version: 2
   commit:

--- a/python-gdal/Dockerfile
+++ b/python-gdal/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.7.10-slim
+
+RUN apt-get update
+RUN apt-get install -y
+
+# Add unstable repo to allow us to access latest GDAL builds
+RUN echo deb http://ftp.uk.debian.org/debian stable main contrib non-free >> /etc/apt/sources.list
+RUN apt-get update
+
+RUN apt-get install -y postgresql-client-11 postgresql-11-postgis-2.5
+
+## Update privs to allow Postgres to run locally
+RUN sed -i "s/local   all             postgres                                peer/local   all             postgres                                trust/" /etc/postgresql/11/main/pg_hba.conf
+
+## Existing binutils causes a dependency conflict, correct version will be installed when GDAL gets intalled
+RUN apt-get remove -y binutils
+
+RUN apt-get update && apt-get install -y gdal-bin libgdal-dev g++
+
+RUN apt-get clean -y && \
+    apt-get autoremove --purge -y && \
+    rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
+
+## Update C env vars so compiler can find gdal
+ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
+ENV C_INCLUDE_PATH=/usr/include/gdal


### PR DESCRIPTION
example taken from: https://github.com/thinkWhere/GDAL-Docker/blob/develop/3.7-shippable/Dockerfile

But I have highly slimed down the image, as we do not need the extra stuff or python:3.7-stretch base image

## To test
- run `docker build python-gdal`
- run `docker run -it --entrypoint /bin/bash {image_id}`
- run `gdal-config --version` within the container 