### PR TITLE
Install libgnutls28-dev

### DIFF
--- a/python-gdal/Dockerfile
+++ b/python-gdal/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s/local   all             postgres                                pe
 ## Existing binutils causes a dependency conflict, correct version will be installed when GDAL gets intalled
 RUN apt-get remove -y binutils
 
-RUN apt-get update && apt-get install -y gdal-bin libgdal-dev libmemcached-dev g++
+RUN apt-get update && apt-get install -y gdal-bin libgdal-dev libmemcached-dev libgnutls28-dev g++
 
 ## Update C env vars so compiler can find gdal
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal


### PR DESCRIPTION
Pycurl needs this package due to `src/pycurl.h:191:13: fatal error: gnutls/gnutls.h: No such file or directory`