### PR TITLE
UNI-2501: Small optimisation for python-psql + postgis removal 

### DIFF
--- a/python-psql/Dockerfile
+++ b/python-psql/Dockerfile
@@ -1,13 +1,15 @@
 FROM python:3.9.9-slim-buster
 
-RUN apt-get update
-RUN apt-get install -y
-
-# Install Postgres12
-RUN apt-get install -y wget ca-certificates gnupg2
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list
-RUN apt-get update
-RUN apt-get -y install postgresql-client-12 postgresql-12-postgis-2.5
+RUN \
+  # Install new postgres deb repo
+  apt-get update && apt-get install -y --no-install-recommends wget ca-certificates gnupg2 \
+  && (wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -) \
+  && (echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list) \
+  # Update package index with new postgres repo data
+  && apt-get update \
+  # Finally install postgres
+  && apt-get install -y --no-install-recommends postgresql-client-12 \
+  # Clean up
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code


### PR DESCRIPTION
1. Using --no-install-requires limits what's being installed.
Smushing all run commands into one makes cleanup easier; we don't need
to keep cache for apt between images.

2. Removed posgis image

Overall these two changes lower the size of this image from 620MB to
511MB.