### PR TITLE
Revert "Vercel: add custom terraform provider to the deploy image"

### DIFF
--- a/circleci-deploy/Dockerfile
+++ b/circleci-deploy/Dockerfile
@@ -29,7 +29,3 @@ RUN curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubunt
     -o "session-manager-plugin.deb" && dpkg -i session-manager-plugin.deb
 
 USER ciuser
-
-# Install custom Vercel provider
-RUN bash -c "$(curl -sSL https://raw.githubusercontent.com/streetteam/gists/main/install_custom_vercel_repo.sh)"
-


### PR DESCRIPTION
Reverts streetteam/docker-images#94
We have now published the provider, this plugin is not needed